### PR TITLE
Add support for HmIP-WGC (#421)

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -839,6 +839,24 @@ class IPGarage(GenericSwitch, GenericBlind, HMSensor):
         return [2]
 
 
+class IPGarageSwitch(GenericSwitch, HelperEventRemote, HMSensor):
+    """
+    HmIP-WGC Garage Actor
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.ATTRIBUTENODE.update({"LOW_BAT": [0],
+                                   "OPERATING_VOLTAGE": [0],
+                                   "RSSI_DEVICE": [0],
+                                   "RSSI_PEER": [0]})
+
+    @property
+    def ELEMENT(self):
+        return [3]
+
+
 class IPMultiIO(IPSwitch):
     """
     HmIP-MIOB Multi IO Box
@@ -1190,6 +1208,7 @@ DEVICETYPES = {
     "HM-Sec-Sir-WM": RFSiren,
     "HmIP-MOD-HO": IPGarage,
     "HmIP-MOD-TM": IPGarage,
+    "HmIP-WGC": IPGarageSwitch,
     "HM-LC-RGBW-WM": ColorEffectLight,
     "HmIP-MIOB": IPMultiIO,
     "HM-DW-WM": Dimmer,


### PR DESCRIPTION
* Created new class IPGarageSwitch and added HmIP-WGC to DEVICETYPES

* Added SENSORNODE to IPGarageSwitch

* Changed to ATTRIBUTENODE for IPGarageSwitch

Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- fixes issue: \<Link to issue>
- adds support for HomeMatic device: \<Device name goes here, e.g. HmIP-ABC-DEF>
  - New class: \<e.g. YourSensor>
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): \<e.g. `DISCOVER_LIGHTS`>
- does the following: \<Description of what the change is intended to do>
